### PR TITLE
🎨 Palette: Improve accessibility of social links and theme toggle icon

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
-## 2024-03-11 - Add ARIA Labels to Repetitive Links
-**Learning:** Repetitive links like "Learn more" (often styled as cards or buttons in mkdocs-material) create a poor screen reader experience because users navigating by links only hear "Learn more" repeatedly without context. Using markdown attribute lists (`{ aria-label="..." }`) allows adding descriptive text for assistive tech while keeping the visual design clean.
-**Action:** Always verify what the screen reader will announce for links that have generic text. When using mkdocs with `attr_list` enabled, use `{ aria-label="..." }` to inject accessible names on links.
+## 2024-05-24 - Social Links ARIA Accessibility in MkDocs Material
+**Learning:** `mkdocs-material` theme's social links (`extra.social`) generate icon-only links. To ensure proper ARIA labels and tooltips are generated for keyboard navigation and screen readers, each link requires an explicitly defined `name` property alongside the `icon` and `link`. Without `name`, the links lack text descriptions.
+**Action:** Always verify `extra.social` links in `mkdocs.yml` have a defined `name` attribute when performing accessibility checks.
+
+## 2024-05-24 - Clarity of System Theme Icon
+**Learning:** The default `material/link` (🔗) icon for the "(prefers-color-scheme)" automatic theme toggle can be confusing to users as it typically implies a URL link rather than a theme setting.
+**Action:** Recommend `material/theme-light-dark` as a more intuitive visual representation for the automatic system theme preference toggle.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,7 +48,7 @@ theme:
   palette:
     - media: "(prefers-color-scheme)"
       toggle:
-        icon: material/link
+        icon: material/theme-light-dark
         name: Switch to light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
@@ -80,16 +80,22 @@ extra:
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/VIP-SMUR
+      name: GitHub
     - icon: fontawesome/brands/researchgate
       link: https://www.researchgate.net/profile/Patrick-Kastner
+      name: ResearchGate
     - icon: fontawesome/brands/google-scholar
       link: https://gscholar.patrickkastner.de/
+      name: Google Scholar
     - icon: fontawesome/brands/linkedin
       link: https://www.linkedin.com/company/106111406
+      name: LinkedIn
     - icon: fontawesome/brands/orcid
       link: https://orcid.org/0000-0003-4940-341X
+      name: ORCID
     - icon: fontawesome/solid/square-rss
       link: https://vip-smur.github.io/feed_rss_created.xml
+      name: RSS Feed
 
 extra_javascript:
   - javascripts/tablesort.js


### PR DESCRIPTION
🎨 Palette: Improve accessibility of social links and theme toggle icon

💡 What:
- Added `name` attribute to all `extra.social` links in `mkdocs.yml`.
- Changed the automatic system theme toggle icon from `material/link` to `material/theme-light-dark`.

🎯 Why:
- Without the `name` attribute, the `mkdocs-material` theme generates icon-only social links without any text description, which is inaccessible.
- The default link (🔗) icon for an automatic theme toggle is confusing to users; a light/dark theme icon is much more intuitive.

♿ Accessibility:
- Social links in the footer will now generate proper `aria-label` attributes and helpful tooltips for screen readers and keyboard users.

---
*PR created automatically by Jules for task [8009992259977059892](https://jules.google.com/task/8009992259977059892) started by @kastnerp*