### PR TITLE
🎨 Palette: Update visually hidden h1 CSS to modern sr-only pattern

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,10 +4,17 @@ hide:
 ---
 
 <style>
-/* find better solution for this later */
+/* Visually hide h1 but keep accessible for screen readers */
 .md-typeset h1 {
   position: absolute;
-  left: -999px;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 </style>
 


### PR DESCRIPTION
💡 **What:** Replaced the outdated `left: -999px;` CSS hack used to visually hide the `<h1>` element on the homepage with a modern, standard `sr-only` (screen-reader only) pattern.

🎯 **Why:** The previous implementation using `position: absolute; left: -999px;` is an older method that can sometimes cause scrolling issues in certain browsers or configurations, especially on very wide screens or in right-to-left (RTL) contexts. The `sr-only` pattern (using `clip`, `width: 1px`, `height: 1px`, `overflow: hidden`, etc.) is the widely accepted, robust standard for hiding content visually while keeping it fully accessible to assistive technologies like screen readers. This directly addresses the existing "find better solution for this later" comment in the code.

📸 **Before/After:** (No visual change, entirely an under-the-hood accessibility improvement)

♿ **Accessibility:** This ensures the `<h1>` element remains fully accessible to screen reader users without causing any unintended layout side effects, improving the robustness of the page's structural accessibility.

---
*PR created automatically by Jules for task [17696318890293683667](https://jules.google.com/task/17696318890293683667) started by @kastnerp*