### PR TITLE
🎨 Palette: Improve accessibility of non-descriptive links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Clarity of System Theme Icon
 **Learning:** The default `material/link` (🔗) icon for the "(prefers-color-scheme)" automatic theme toggle can be confusing to users as it typically implies a URL link rather than a theme setting.
 **Action:** Recommend `material/theme-light-dark` as a more intuitive visual representation for the automatic system theme preference toggle.
+
+## $(date +%Y-%m-%d) - Adding Aria-Labels to Images and Non-Descriptive Links
+**Learning:** Raw HTML in markdown files (`macleamy.md`) and configuration files (`mkdocs.yml`) containing links often lack sufficient context for screen reader users when they navigate by link, particularly when the text is short like "(more info)" or contains only an image.
+**Action:** When finding raw HTML `<a>` tags around images or with non-descriptive link text, always add an explicit `aria-label` describing the destination or action.

--- a/docs/macleamy.md
+++ b/docs/macleamy.md
@@ -1,5 +1,5 @@
 <figure markdown="span">
   ![MacLeamy Influence Curve](images/SVG/InfluenceCurveWhite.svg#dark-only){ align=left, width="640",  .off-glb}
   ![MacLeamy Influence Curve](images/SVG/InfluenceCurveBlack.svg#light-only){ align=left, width="640", .off-glb }
-  <figcaption><a href="https://www.youtube.com/watch?v=9bUlBYc_Gl4">MacLeamy Curve</a> illustrating the need for rapid performance feedback in architectural decision-making. <a href="https://www.danieldavis.com/macleamy/">(more info)</a></figcaption>
+  <figcaption><a href="https://www.youtube.com/watch?v=9bUlBYc_Gl4">MacLeamy Curve</a> illustrating the need for rapid performance feedback in architectural decision-making. <a href="https://www.danieldavis.com/macleamy/" aria-label="More information about the MacLeamy curve">(more info)</a></figcaption>
 </figure>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ site_description: >-
 
 # Copyright
 copyright: >-
-  Copyright &copy; 2023-2026 Sustainable Urban Systems Lab. <a href="https://siddharthdasari.com/">Design credits.</a><p><a href="https://github.com/VIP-SMUR/vip-smur.github.io/actions"><img alt="Last Built" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2FVIP-SMUR%2Fvip-smur.github.io%2Factions%2Fworkflows%2F119410802%2Fruns%3Fstatus%3Dcompleted%26per_page%3D1&query=%24.workflow_runs%5B0%5D.run_started_at&style=flat-square&label=Last%20Built&cacheSeconds=720"></a>
+  Copyright &copy; 2023-2026 Sustainable Urban Systems Lab. <a href="https://siddharthdasari.com/">Design credits.</a><p><a href="https://github.com/VIP-SMUR/vip-smur.github.io/actions" aria-label="View GitHub Actions build status"><img alt="Last Built" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2FVIP-SMUR%2Fvip-smur.github.io%2Factions%2Fworkflows%2F119410802%2Fruns%3Fstatus%3Dcompleted%26per_page%3D1&query=%24.workflow_runs%5B0%5D.run_started_at&style=flat-square&label=Last%20Built&cacheSeconds=720"></a>
 
 theme:
   name: material


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the "(more info)" link in `docs/macleamy.md` and the GitHub Actions badge in `mkdocs.yml`.
🎯 Why: "More info" and image-only links lack context for users navigating by screen reader. Providing an explicit `aria-label` ensures the destination or action is clearly described.
♿ Accessibility: Improved screen reader navigation for ambiguous or image-only HTML links.

---
*PR created automatically by Jules for task [12693343929828315885](https://jules.google.com/task/12693343929828315885) started by @kastnerp*