### PR TITLE
🎨 Palette: Improve social link ARIA labels and navigation UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## $(date +%Y-%m-%d) - Adding Aria-Labels to Images and Non-Descriptive Links
 **Learning:** Raw HTML in markdown files (`macleamy.md`) and configuration files (`mkdocs.yml`) containing links often lack sufficient context for screen reader users when they navigate by link, particularly when the text is short like "(more info)" or contains only an image.
 **Action:** When finding raw HTML `<a>` tags around images or with non-descriptive link text, always add an explicit `aria-label` describing the destination or action.
+
+## 2026-03-19 - Full Context for Social Icons
+**Learning:** Social icon links in MkDocs with generic names like "GitHub" or "LinkedIn" fail to provide sufficient context for screen reader users navigating out of context. They only hear "GitHub, link" instead of knowing whose profile it leads to.
+**Action:** Always prefix or suffix generic social platform names with the account name or organization name (e.g., "VIP-SMUR on GitHub" or "Patrick Kastner on ORCID") to ensure unambiguous navigation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ hide:
 ![SustainLab Logo](images/sustainlab-smur-logo-wordmark-color-white.svg#dark-only){ align=left, width="500", .off-glb}
 ![SustainLab Logo](images/sustainlab-smur-logo-wordmark-color-black.svg#light-only){ align=left, width="500", .off-glb}
 
-Welcome to the project page of the [VIP][VIP] team [Surrogate Modeling for Urban Regeneration](https://vip-smur.github.io/) (SMUR) at Georgia Tech.
+Welcome to the project page of the [VIP][VIP] team Surrogate Modeling for Urban Regeneration (SMUR) at Georgia Tech.
 This course is led by Dr. Patrick Kastner, head of the [Sustainable Urban Systems Lab](https://sustain.arch.gatech.edu).
 
 ## 📝 The Problem
@@ -72,7 +72,7 @@ We're happy to help!
   
 ## 📊 Project Overview
 
-Our [current and previous projects](https://vip-smur.github.io/projects/) include topics on:
+Our [current and previous projects](projects/index.md) include topics on:
 
 1. Energy in Buildings
 2. Urban Microclimate

--- a/docs/macleamy.md
+++ b/docs/macleamy.md
@@ -1,5 +1,5 @@
 <figure markdown="span">
   ![MacLeamy Influence Curve](images/SVG/InfluenceCurveWhite.svg#dark-only){ align=left, width="640",  .off-glb}
   ![MacLeamy Influence Curve](images/SVG/InfluenceCurveBlack.svg#light-only){ align=left, width="640", .off-glb }
-  <figcaption><a href="https://www.youtube.com/watch?v=9bUlBYc_Gl4">MacLeamy Curve</a> illustrating the need for rapid performance feedback in architectural decision-making. <a href="https://www.danieldavis.com/macleamy/" aria-label="More information about the MacLeamy curve">(more info)</a></figcaption>
+  <figcaption><a href="https://www.youtube.com/watch?v=9bUlBYc_Gl4" aria-label="Watch MacLeamy Curve explanation on YouTube">MacLeamy Curve</a> illustrating the need for rapid performance feedback in architectural decision-making. <a href="https://www.danieldavis.com/macleamy/" aria-label="More information about the MacLeamy curve">(more info)</a></figcaption>
 </figure>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,22 +80,22 @@ extra:
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/VIP-SMUR
-      name: GitHub
+      name: VIP-SMUR on GitHub
     - icon: fontawesome/brands/researchgate
       link: https://www.researchgate.net/profile/Patrick-Kastner
-      name: ResearchGate
+      name: Patrick Kastner on ResearchGate
     - icon: fontawesome/brands/google-scholar
       link: https://gscholar.patrickkastner.de/
-      name: Google Scholar
+      name: Patrick Kastner on Google Scholar
     - icon: fontawesome/brands/linkedin
       link: https://www.linkedin.com/company/106111406
-      name: LinkedIn
+      name: VIP-SMUR on LinkedIn
     - icon: fontawesome/brands/orcid
       link: https://orcid.org/0000-0003-4940-341X
-      name: ORCID
+      name: Patrick Kastner on ORCID
     - icon: fontawesome/solid/square-rss
       link: https://vip-smur.github.io/feed_rss_created.xml
-      name: RSS Feed
+      name: VIP-SMUR RSS Feed
 
 extra_javascript:
   - javascripts/tablesort.js


### PR DESCRIPTION
💡 What:
- Updated social link names in `mkdocs.yml` to be descriptive (e.g., "GitHub" -> "VIP-SMUR on GitHub")
- Added `aria-label` to the YouTube link in `macleamy.md`
- Fixed self-referencing and absolute navigation links in `index.md`
- Documented learning in `.Jules/palette.md`

🎯 Why:
- Screen readers read social icons as just "GitHub, link", which lacks context. By renaming them, the generated tooltip and ARIA label provide full destination context.
- Unlabeled raw HTML video links lack context when navigating by link.
- Absolute links in single-page apps (like MkDocs Material) cause full page reloads instead of fast, seamless client-side routing.

♿ Accessibility:
- Significantly improved the experience for screen reader users relying on link context and navigation out-of-context.

---
*PR created automatically by Jules for task [1819947871555654023](https://jules.google.com/task/1819947871555654023) started by @kastnerp*