### PR TITLE
🎨 Palette: Add ARIA labels to raw HTML links

### DIFF
--- a/docs/activities/outreach.md
+++ b/docs/activities/outreach.md
@@ -5,7 +5,7 @@
 <figure markdown="span">
   ![Fall 2025 Sustainability Network Meeting](25-SustainabilityNetworkMeeting.jpeg)
   <figcaption>
-    Joseph Aerathu and Matthew Lim representing our VIP at the Fall 2025 <a href="https://research.gatech.edu/georgia-tech-sustainability-network">Sustainability Network Meeting</a>.
+    Joseph Aerathu and Matthew Lim representing our VIP at the Fall 2025 <a href="https://research.gatech.edu/georgia-tech-sustainability-network" aria-label="Georgia Tech Sustainability Network Meeting">Sustainability Network Meeting</a>.
   </figcaption>
 </figure>
 
@@ -14,7 +14,7 @@
 <figure markdown="span">
   ![VIP-SMUR ISyE Summer Scholars Program](25-SURS-Justin.jpg)
   <figcaption>
-    Justin Xu presenting his contributions to the <a href="https://vip-smur.github.io/25sp-mponc/">MPONC</a> project as part of the <a href="https://ugresearch.isye.gatech.edu/research-awards-programs/summer-scholars-program">ISyE Summer Scholars Program</a>.
+    Justin Xu presenting his contributions to the <a href="https://vip-smur.github.io/25sp-mponc/" aria-label="MPONC Project Page">MPONC</a> project as part of the <a href="https://ugresearch.isye.gatech.edu/research-awards-programs/summer-scholars-program" aria-label="ISyE Summer Scholars Program at Georgia Tech">ISyE Summer Scholars Program</a>.
   </figcaption>
 </figure>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ site_description: >-
 
 # Copyright
 copyright: >-
-  Copyright &copy; 2023-2026 Sustainable Urban Systems Lab. <a href="https://siddharthdasari.com/">Design credits.</a><p><a href="https://github.com/VIP-SMUR/vip-smur.github.io/actions" aria-label="View GitHub Actions build status"><img alt="Last Built" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2FVIP-SMUR%2Fvip-smur.github.io%2Factions%2Fworkflows%2F119410802%2Fruns%3Fstatus%3Dcompleted%26per_page%3D1&query=%24.workflow_runs%5B0%5D.run_started_at&style=flat-square&label=Last%20Built&cacheSeconds=720"></a>
+  Copyright &copy; 2023-2026 Sustainable Urban Systems Lab. <a href="https://siddharthdasari.com/" aria-label="Design credits by Siddharth Dasari">Design credits.</a><p><a href="https://github.com/VIP-SMUR/vip-smur.github.io/actions" aria-label="View GitHub Actions build status"><img alt="Last Built" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2FVIP-SMUR%2Fvip-smur.github.io%2Factions%2Fworkflows%2F119410802%2Fruns%3Fstatus%3Dcompleted%26per_page%3D1&query=%24.workflow_runs%5B0%5D.run_started_at&style=flat-square&label=Last%20Built&cacheSeconds=720"></a>
 
 theme:
   name: material


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label` attributes to inline HTML anchor (`<a>`) tags within `docs/activities/outreach.md` and `mkdocs.yml`.

🎯 **Why:** To ensure screen-reader users have sufficient context when navigating links out of context. For instance, a generic link like "Design credits" or "MPONC" alone may not convey the destination clearly without the surrounding text. The `aria-labels` added (e.g., "Design credits by Siddharth Dasari", "MPONC Project Page") solve this.

♿ **Accessibility:** This directly improves navigation for screen readers by providing clear, descriptive labels for interactive elements that otherwise rely on visual context or short text snippets. All added `aria-labels` encompass the visible text to comply with voice-control best practices (e.g., "MPONC" is within "MPONC Project Page").

---
*PR created automatically by Jules for task [453036928563657074](https://jules.google.com/task/453036928563657074) started by @kastnerp*