### PR TITLE
🎨 Palette: Add aria-label to raw HTML anchor tags in outreach.md

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2026-03-19 - Full Context for Social Icons
 **Learning:** Social icon links in MkDocs with generic names like "GitHub" or "LinkedIn" fail to provide sufficient context for screen reader users navigating out of context. They only hear "GitHub, link" instead of knowing whose profile it leads to.
 **Action:** Always prefix or suffix generic social platform names with the account name or organization name (e.g., "VIP-SMUR on GitHub" or "Patrick Kastner on ORCID") to ensure unambiguous navigation.
+## 2025-03-22 - [Raw HTML Anchor Tags in MkDocs Captions]
+**Learning:** Raw HTML `<a>` tags embedded in Markdown files (like in `<figcaption>` elements) lack screen-reader context if the text is generic.
+**Action:** Ensure all raw HTML anchor tags include descriptive `aria-label` attributes for accessibility.

--- a/docs/activities/outreach.md
+++ b/docs/activities/outreach.md
@@ -22,14 +22,14 @@
 
 <figure markdown="span">
   ![VIP-SMUR Georgia Undergraduate Research Conference 2024 in Oxford, GA](24-GURC.jpg)
-  <figcaption><a href="https://sustainableurbansystems.com/news/announcement_25/">Georgia Undergraduate Research Conference 2024 in Oxford, GA</a>
+  <figcaption><a href="https://sustainableurbansystems.com/news/announcement_25/" aria-label="Learn more about the Georgia Undergraduate Research Conference 2024 in Oxford, GA">Georgia Undergraduate Research Conference 2024 in Oxford, GA</a>
 
   Anubha Mahajan, Jessica Hernandez, Jiayi Li, Joseph Mathew Aerathu, Sharmista Debnath, Kiana-Karla Layam,  Han-Syun Shih, Hang Xu, and Patrick Kastner. Photo credits: Han-Syun Shih</figcaption>
 </figure>
 
 <figure markdown="span">
   ![VIP-SMUR at the GNI Symposium & Expo on Artificial Intelligence for the Built World](24-GNI.jpeg)
-  <figcaption><a href="https://sustainableurbansystems.com/news/announcement_24/">GNI Symposium on AI for the Built World in Munich, Germany.</a><br>
+  <figcaption><a href="https://sustainableurbansystems.com/news/announcement_24/" aria-label="Learn more about the GNI Symposium on AI for the Built World in Munich, Germany">GNI Symposium on AI for the Built World in Munich, Germany.</a><br>
 
   Ze Yu Jiang, Sofia Mujica, Silvia Vangelova, and Patrick Kastner</figcaption>
 </figure>


### PR DESCRIPTION
🎨 **Palette: Added aria-label to raw HTML anchor tags in `outreach.md`**

💡 **What:** Added `aria-label` attributes to the raw HTML anchor tags in the image caption elements in `docs/activities/outreach.md` and added an entry to `.Jules/palette.md`.
🎯 **Why:** To improve accessibility. Although the visible link text is somewhat descriptive, it is sometimes rendered in a way that needs further context for screen reader users or provides duplicate links context. I added context such as "Learn more about...".
♿ **Accessibility:** Added `aria-label` to provide more verbose context for screen readers parsing raw HTML `<a>` tags inside `<figcaption>` blocks.

---
*PR created automatically by Jules for task [11937800353603807111](https://jules.google.com/task/11937800353603807111) started by @kastnerp*