### PR TITLE
🎨 Palette: Semantic Structure for Images with Captions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,7 @@
 ## 2025-03-22 - [Raw HTML Anchor Tags in MkDocs Captions]
 **Learning:** Raw HTML `<a>` tags embedded in Markdown files (like in `<figcaption>` elements) lack screen-reader context if the text is generic.
 **Action:** Ensure all raw HTML anchor tags include descriptive `aria-label` attributes for accessibility.
+
+## 2026-03-24 - Semantic Structure for Images with Captions
+**Learning:** Using raw markdown images (`![alt](url)`) and separate text for captions is poor for accessibility as screen readers don't semantically associate the text with the image.
+**Action:** Always use `<figure markdown="span">` containing an image and a `<figcaption>` element to provide semantic structure and improve accessibility for images with captions.

--- a/docs/team/26-Sp.md
+++ b/docs/team/26-Sp.md
@@ -4,7 +4,14 @@ hide:
 ---
 
 # Spring 2026
+
+<figure markdown="span">
+
 ![Spring 2026 Team](26-Sp-ClassPhoto.jpg)
+
+  <figcaption>SMUR Spring 2026 Team Picture</figcaption>
+
+</figure>
 
 **Class Lead:** Patrick Kastner
 


### PR DESCRIPTION
💡 What: Updated `docs/team/26-Sp.md` to wrap the team image in a `<figure markdown="span">` tag with a semantic `<figcaption>`.
🎯 Why: Using raw markdown images with separate text for captions is poor for accessibility as screen readers don't semantically associate the text with the image. The new structure links them together explicitly and follows existing repository patterns.
♿ Accessibility: Improved semantic association of image and its description.

---
*PR created automatically by Jules for task [13176108801166588403](https://jules.google.com/task/13176108801166588403) started by @kastnerp*