### PR TITLE
🎨 Palette: Remove redundant ARIA labels from descriptive links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,7 +6,7 @@
 **Learning:** The default `material/link` (🔗) icon for the "(prefers-color-scheme)" automatic theme toggle can be confusing to users as it typically implies a URL link rather than a theme setting.
 **Action:** Recommend `material/theme-light-dark` as a more intuitive visual representation for the automatic system theme preference toggle.
 
-## $(date +%Y-%m-%d) - Adding Aria-Labels to Images and Non-Descriptive Links
+## 2026-03-26 - Adding Aria-Labels to Images and Non-Descriptive Links
 **Learning:** Raw HTML in markdown files (`macleamy.md`) and configuration files (`mkdocs.yml`) containing links often lack sufficient context for screen reader users when they navigate by link, particularly when the text is short like "(more info)" or contains only an image.
 **Action:** When finding raw HTML `<a>` tags around images or with non-descriptive link text, always add an explicit `aria-label` describing the destination or action.
 
@@ -20,3 +20,7 @@
 ## 2026-03-24 - Semantic Structure for Images with Captions
 **Learning:** Using raw markdown images (`![alt](url)`) and separate text for captions is poor for accessibility as screen readers don't semantically associate the text with the image.
 **Action:** Always use `<figure markdown="span">` containing an image and a `<figcaption>` element to provide semantic structure and improve accessibility for images with captions.
+
+## 2026-03-26 - Avoiding Redundant ARIA Labels
+**Learning:** Adding `aria-label` attributes to `<a>` tags where the visible text is already highly descriptive (e.g., "Sustainability Network Meeting") causes unnecessary verbosity for screen readers. ARIA labels should only be applied to generic text like "Learn more" or "(more info)", or icon-only buttons.
+**Action:** When performing accessibility checks or applying UX improvements, avoid adding redundant `aria-label` attributes to links that already have highly descriptive visible text.

--- a/docs/activities/outreach.md
+++ b/docs/activities/outreach.md
@@ -5,7 +5,7 @@
 <figure markdown="span">
   ![Fall 2025 Sustainability Network Meeting](25-SustainabilityNetworkMeeting.jpeg)
   <figcaption>
-    Joseph Aerathu and Matthew Lim representing our VIP at the Fall 2025 <a href="https://research.gatech.edu/georgia-tech-sustainability-network" aria-label="Georgia Tech Sustainability Network Meeting">Sustainability Network Meeting</a>.
+    Joseph Aerathu and Matthew Lim representing our VIP at the Fall 2025 <a href="https://research.gatech.edu/georgia-tech-sustainability-network">Sustainability Network Meeting</a>.
   </figcaption>
 </figure>
 
@@ -14,7 +14,7 @@
 <figure markdown="span">
   ![VIP-SMUR ISyE Summer Scholars Program](25-SURS-Justin.jpg)
   <figcaption>
-    Justin Xu presenting his contributions to the <a href="https://vip-smur.github.io/25sp-mponc/" aria-label="MPONC Project Page">MPONC</a> project as part of the <a href="https://ugresearch.isye.gatech.edu/research-awards-programs/summer-scholars-program" aria-label="ISyE Summer Scholars Program at Georgia Tech">ISyE Summer Scholars Program</a>.
+    Justin Xu presenting his contributions to the <a href="https://vip-smur.github.io/25sp-mponc/">MPONC</a> project as part of the <a href="https://ugresearch.isye.gatech.edu/research-awards-programs/summer-scholars-program">ISyE Summer Scholars Program</a>.
   </figcaption>
 </figure>
 
@@ -22,14 +22,14 @@
 
 <figure markdown="span">
   ![VIP-SMUR Georgia Undergraduate Research Conference 2024 in Oxford, GA](24-GURC.jpg)
-  <figcaption><a href="https://sustainableurbansystems.com/news/announcement_25/" aria-label="Learn more about the Georgia Undergraduate Research Conference 2024 in Oxford, GA">Georgia Undergraduate Research Conference 2024 in Oxford, GA</a>
+  <figcaption><a href="https://sustainableurbansystems.com/news/announcement_25/">Georgia Undergraduate Research Conference 2024 in Oxford, GA</a>
 
   Anubha Mahajan, Jessica Hernandez, Jiayi Li, Joseph Mathew Aerathu, Sharmista Debnath, Kiana-Karla Layam,  Han-Syun Shih, Hang Xu, and Patrick Kastner. Photo credits: Han-Syun Shih</figcaption>
 </figure>
 
 <figure markdown="span">
   ![VIP-SMUR at the GNI Symposium & Expo on Artificial Intelligence for the Built World](24-GNI.jpeg)
-  <figcaption><a href="https://sustainableurbansystems.com/news/announcement_24/" aria-label="Learn more about the GNI Symposium on AI for the Built World in Munich, Germany">GNI Symposium on AI for the Built World in Munich, Germany.</a><br>
+  <figcaption><a href="https://sustainableurbansystems.com/news/announcement_24/">GNI Symposium on AI for the Built World in Munich, Germany.</a><br>
 
   Ze Yu Jiang, Sofia Mujica, Silvia Vangelova, and Patrick Kastner</figcaption>
 </figure>

--- a/docs/macleamy.md
+++ b/docs/macleamy.md
@@ -1,5 +1,5 @@
 <figure markdown="span">
   ![MacLeamy Influence Curve](images/SVG/InfluenceCurveWhite.svg#dark-only){ align=left, width="640",  .off-glb}
   ![MacLeamy Influence Curve](images/SVG/InfluenceCurveBlack.svg#light-only){ align=left, width="640", .off-glb }
-  <figcaption><a href="https://www.youtube.com/watch?v=9bUlBYc_Gl4" aria-label="Watch MacLeamy Curve explanation on YouTube">MacLeamy Curve</a> illustrating the need for rapid performance feedback in architectural decision-making. <a href="https://www.danieldavis.com/macleamy/" aria-label="More information about the MacLeamy curve">(more info)</a></figcaption>
+  <figcaption><a href="https://www.youtube.com/watch?v=9bUlBYc_Gl4">MacLeamy Curve</a> illustrating the need for rapid performance feedback in architectural decision-making. <a href="https://www.danieldavis.com/macleamy/" aria-label="More information about the MacLeamy curve">(more info)</a></figcaption>
 </figure>


### PR DESCRIPTION
💡 What: Removed redundant `aria-label` attributes from highly descriptive `<a>` tag links (e.g., "Sustainability Network Meeting") in markdown files (`docs/activities/outreach.md` and `docs/macleamy.md`). Left them in place for generic links like `(more info)`.

🎯 Why: Overriding visible text with an `aria-label` when the text is already descriptive provides no additional context. Worse, it creates unnecessary verbosity for screen readers and can actively hinder voice dictation users who rely on speaking the exact visible text to activate elements.

📸 Before/After: Visual presentation is identical; DOM is cleaner.

♿ Accessibility: Reduced screen reader noise and verbosity. Voice dictation is more predictable. Recorded this finding in Palette's journal.

---
*PR created automatically by Jules for task [5420097520636911065](https://jules.google.com/task/5420097520636911065) started by @kastnerp*