### PR TITLE
🎨 Palette: Improve accessibility of external links in captions

### DIFF
--- a/docs/activities/outreach.md
+++ b/docs/activities/outreach.md
@@ -5,7 +5,7 @@
 <figure markdown="span">
   ![Fall 2025 Sustainability Network Meeting](25-SustainabilityNetworkMeeting.jpeg)
   <figcaption>
-    Joseph Aerathu and Matthew Lim representing our VIP at the Fall 2025 <a href="https://research.gatech.edu/georgia-tech-sustainability-network">Sustainability Network Meeting</a>.
+    Joseph Aerathu and Matthew Lim representing our VIP at the Fall 2025 <a href="https://research.gatech.edu/georgia-tech-sustainability-network" target="_blank" rel="noopener noreferrer" aria-label="Sustainability Network Meeting (opens in a new tab)">Sustainability Network Meeting</a>.
   </figcaption>
 </figure>
 
@@ -14,7 +14,7 @@
 <figure markdown="span">
   ![VIP-SMUR ISyE Summer Scholars Program](25-SURS-Justin.jpg)
   <figcaption>
-    Justin Xu presenting his contributions to the <a href="https://vip-smur.github.io/25sp-mponc/">MPONC</a> project as part of the <a href="https://ugresearch.isye.gatech.edu/research-awards-programs/summer-scholars-program">ISyE Summer Scholars Program</a>.
+    Justin Xu presenting his contributions to the <a href="https://vip-smur.github.io/25sp-mponc/" target="_blank" rel="noopener noreferrer" aria-label="MPONC (opens in a new tab)">MPONC</a> project as part of the <a href="https://ugresearch.isye.gatech.edu/research-awards-programs/summer-scholars-program" target="_blank" rel="noopener noreferrer" aria-label="ISyE Summer Scholars Program (opens in a new tab)">ISyE Summer Scholars Program</a>.
   </figcaption>
 </figure>
 
@@ -22,14 +22,14 @@
 
 <figure markdown="span">
   ![VIP-SMUR Georgia Undergraduate Research Conference 2024 in Oxford, GA](24-GURC.jpg)
-  <figcaption><a href="https://sustainableurbansystems.com/news/announcement_25/">Georgia Undergraduate Research Conference 2024 in Oxford, GA</a>
+  <figcaption><a href="https://sustainableurbansystems.com/news/announcement_25/" target="_blank" rel="noopener noreferrer" aria-label="Georgia Undergraduate Research Conference 2024 in Oxford, GA (opens in a new tab)">Georgia Undergraduate Research Conference 2024 in Oxford, GA</a>
 
   Anubha Mahajan, Jessica Hernandez, Jiayi Li, Joseph Mathew Aerathu, Sharmista Debnath, Kiana-Karla Layam,  Han-Syun Shih, Hang Xu, and Patrick Kastner. Photo credits: Han-Syun Shih</figcaption>
 </figure>
 
 <figure markdown="span">
   ![VIP-SMUR at the GNI Symposium & Expo on Artificial Intelligence for the Built World](24-GNI.jpeg)
-  <figcaption><a href="https://sustainableurbansystems.com/news/announcement_24/">GNI Symposium on AI for the Built World in Munich, Germany.</a><br>
+  <figcaption><a href="https://sustainableurbansystems.com/news/announcement_24/" target="_blank" rel="noopener noreferrer" aria-label="GNI Symposium on AI for the Built World in Munich, Germany (opens in a new tab)">GNI Symposium on AI for the Built World in Munich, Germany.</a><br>
 
   Ze Yu Jiang, Sofia Mujica, Silvia Vangelova, and Patrick Kastner</figcaption>
 </figure>

--- a/docs/macleamy.md
+++ b/docs/macleamy.md
@@ -1,5 +1,5 @@
 <figure markdown="span">
   ![MacLeamy Influence Curve](images/SVG/InfluenceCurveWhite.svg#dark-only){ align=left, width="640",  .off-glb}
   ![MacLeamy Influence Curve](images/SVG/InfluenceCurveBlack.svg#light-only){ align=left, width="640", .off-glb }
-  <figcaption><a href="https://www.youtube.com/watch?v=9bUlBYc_Gl4">MacLeamy Curve</a> illustrating the need for rapid performance feedback in architectural decision-making. <a href="https://www.danieldavis.com/macleamy/" aria-label="More information about the MacLeamy curve">(more info)</a></figcaption>
+  <figcaption><a href="https://www.youtube.com/watch?v=9bUlBYc_Gl4" target="_blank" rel="noopener noreferrer" aria-label="MacLeamy Curve (opens in a new tab)">MacLeamy Curve</a> illustrating the need for rapid performance feedback in architectural decision-making. <a href="https://www.danieldavis.com/macleamy/" target="_blank" rel="noopener noreferrer" aria-label="More information about the MacLeamy curve (opens in a new tab)">(more info)</a></figcaption>
 </figure>


### PR DESCRIPTION
💡 What: Added `target="_blank"`, `rel="noopener noreferrer"`, and `aria-label="... (opens in a new tab)"` to external `<a>` tags inside `<figcaption>` elements in `docs/macleamy.md` and `docs/activities/outreach.md`.
🎯 Why: Screen reader users need explicit context when a link is going to open in a new window to prevent confusion. Opening external documentation or external references in a new tab keeps users from losing their place in the SMUR documentation. The `noopener noreferrer` attributes prevent security vulnerabilities.
♿ Accessibility: Improves WCAG compliance by warning screen reader users of context shifts and provides a more intuitive browsing experience.

---
*PR created automatically by Jules for task [2411354036663509936](https://jules.google.com/task/2411354036663509936) started by @kastnerp*