### PR TITLE
🎨 Palette: Improve theme toggle icons and external link accessibility

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ site_description: >-
 
 # Copyright
 copyright: >-
-  Copyright &copy; 2023-2026 Sustainable Urban Systems Lab. <a href="https://siddharthdasari.com/" aria-label="Design credits by Siddharth Dasari">Design credits.</a><p><a href="https://github.com/VIP-SMUR/vip-smur.github.io/actions" aria-label="View GitHub Actions build status"><img alt="Last Built" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2FVIP-SMUR%2Fvip-smur.github.io%2Factions%2Fworkflows%2F119410802%2Fruns%3Fstatus%3Dcompleted%26per_page%3D1&query=%24.workflow_runs%5B0%5D.run_started_at&style=flat-square&label=Last%20Built&cacheSeconds=720"></a>
+  Copyright &copy; 2023-2026 Sustainable Urban Systems Lab. <a href="https://siddharthdasari.com/" target="_blank" rel="noopener noreferrer" aria-label="Design credits by Siddharth Dasari (opens in a new tab)">Design credits.</a><p><a href="https://github.com/VIP-SMUR/vip-smur.github.io/actions" target="_blank" rel="noopener noreferrer" aria-label="View GitHub Actions build status (opens in a new tab)"><img alt="Last Built" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2FVIP-SMUR%2Fvip-smur.github.io%2Factions%2Fworkflows%2F119410802%2Fruns%3Fstatus%3Dcompleted%26per_page%3D1&query=%24.workflow_runs%5B0%5D.run_started_at&style=flat-square&label=Last%20Built&cacheSeconds=720"></a>
 
 theme:
   name: material
@@ -48,21 +48,21 @@ theme:
   palette:
     - media: "(prefers-color-scheme)"
       toggle:
-        icon: material/theme-light-dark
+        icon: material/weather-sunny
         name: Switch to light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
       primary: black
       accent: black
       toggle:
-        icon: material/toggle-switch
+        icon: material/weather-night
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
       primary: black
       accent: indigo
       toggle:
-        icon: material/toggle-switch-off
+        icon: material/theme-light-dark
         name: Switch to system preference
 
 extra_css:


### PR DESCRIPTION
💡 What:
1. Updated the `icon` properties in the `mkdocs.yml` color palette toggle to be semantically correct for the state they transition to (e.g., `material/weather-sunny` to switch to light mode, `material/weather-night` to switch to dark mode, and `material/theme-light-dark` to switch to system preference).
2. Added `target="_blank" rel="noopener noreferrer"` to external links in the footer copyright string, and appended `(opens in a new tab)` to their `aria-label`s.

🎯 Why:
1. The previous default icons (`material/toggle-switch`, `material/toggle-switch-off`, and `material/theme-light-dark` in mismatched contexts) were visually ambiguous. Context-aware icons like the sun and moon provide immediate, intuitive feedback on what clicking the button will achieve.
2. Opening external links in a new tab prevents users from losing their place in the documentation. Adding `(opens in a new tab)` to the ARIA label ensures screen reader users are alerted to this context switch, improving overall accessibility and adhering to WCAG guidelines.

♿ Accessibility:
Improved screen reader context for external copyright links by ensuring their `aria-label`s indicate when a link opens in a new tab.

---
*PR created automatically by Jules for task [631027868325738456](https://jules.google.com/task/631027868325738456) started by @kastnerp*