### PR TITLE
Revert "Palette: Improve theme toggle icons and external link accessibility in mkdocs.yml (#45)"

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -24,3 +24,6 @@
 ## 2026-03-26 - Avoiding Redundant ARIA Labels
 **Learning:** Adding `aria-label` attributes to `<a>` tags where the visible text is already highly descriptive (e.g., "Sustainability Network Meeting") causes unnecessary verbosity for screen readers. ARIA labels should only be applied to generic text like "Learn more" or "(more info)", or icon-only buttons.
 **Action:** When performing accessibility checks or applying UX improvements, avoid adding redundant `aria-label` attributes to links that already have highly descriptive visible text.
+## 2026-04-01 - [Theme Toggle Icons]
+**Learning:** The user explicitly requested that the semantics of the symbols (icons) for the color palette theme toggle should not be changed.
+**Action:** When updating the MkDocs Material palette settings in `mkdocs.yml`, always keep the default icons (`material/theme-light-dark`, `material/toggle-switch`, `material/toggle-switch-off`). Do not replace them with sun/moon or context-aware icons.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ site_description: >-
 
 # Copyright
 copyright: >-
-  Copyright &copy; 2023-2026 Sustainable Urban Systems Lab. <a href="https://siddharthdasari.com/" target="_blank" rel="noopener noreferrer" aria-label="Design credits by Siddharth Dasari (opens in a new tab)">Design credits.</a><p><a href="https://github.com/VIP-SMUR/vip-smur.github.io/actions" target="_blank" rel="noopener noreferrer" aria-label="View GitHub Actions build status (opens in a new tab)"><img alt="Last Built" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2FVIP-SMUR%2Fvip-smur.github.io%2Factions%2Fworkflows%2F119410802%2Fruns%3Fstatus%3Dcompleted%26per_page%3D1&query=%24.workflow_runs%5B0%5D.run_started_at&style=flat-square&label=Last%20Built&cacheSeconds=720"></a>
+  Copyright &copy; 2023-2026 Sustainable Urban Systems Lab. <a href="https://siddharthdasari.com/" aria-label="Design credits by Siddharth Dasari">Design credits.</a><p><a href="https://github.com/VIP-SMUR/vip-smur.github.io/actions" aria-label="View GitHub Actions build status"><img alt="Last Built" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2FVIP-SMUR%2Fvip-smur.github.io%2Factions%2Fworkflows%2F119410802%2Fruns%3Fstatus%3Dcompleted%26per_page%3D1&query=%24.workflow_runs%5B0%5D.run_started_at&style=flat-square&label=Last%20Built&cacheSeconds=720"></a>
 
 theme:
   name: material
@@ -46,23 +46,24 @@ theme:
     # - toc.integrate
 
   palette:
+    # Do not change the semantics of these symbols (icons) for the theme toggle.
     - media: "(prefers-color-scheme)"
       toggle:
-        icon: material/weather-sunny
+        icon: material/theme-light-dark
         name: Switch to light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
       primary: black
       accent: black
       toggle:
-        icon: material/weather-night
+        icon: material/toggle-switch
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
       primary: black
       accent: indigo
       toggle:
-        icon: material/theme-light-dark
+        icon: material/toggle-switch-off
         name: Switch to system preference
 
 extra_css:


### PR DESCRIPTION
This reverts the changes introduced in PR #45 regarding the theme toggle icons and external links.

* Reverted the `icon` properties in the `mkdocs.yml` color palette toggle back to the original default icons (`material/theme-light-dark`, `material/toggle-switch`, `material/toggle-switch-off`).
* Reverted the external link changes in the footer copyright string, removing `target="_blank" rel="noopener noreferrer"` and `(opens in a new tab)` from the `aria-label`s.
* Added a comment in `mkdocs.yml` to ensure the semantics of the symbols (icons) for the theme toggle are not changed in the future.
* Documented this requirement in `.Jules/palette.md` for future reference.

---
*PR created automatically by Jules for task [13935279635217581055](https://jules.google.com/task/13935279635217581055) started by @kastnerp*