### PR TITLE
🎨 Palette: Improve accessibility of external links in footer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ site_description: >-
 
 # Copyright
 copyright: >-
-  Copyright &copy; 2023-2026 Sustainable Urban Systems Lab. <a href="https://siddharthdasari.com/" aria-label="Design credits by Siddharth Dasari">Design credits.</a><p><a href="https://github.com/VIP-SMUR/vip-smur.github.io/actions" aria-label="View GitHub Actions build status"><img alt="Last Built" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2FVIP-SMUR%2Fvip-smur.github.io%2Factions%2Fworkflows%2F119410802%2Fruns%3Fstatus%3Dcompleted%26per_page%3D1&query=%24.workflow_runs%5B0%5D.run_started_at&style=flat-square&label=Last%20Built&cacheSeconds=720"></a>
+  Copyright &copy; 2023-2026 Sustainable Urban Systems Lab. <a href="https://siddharthdasari.com/" target="_blank" rel="noopener noreferrer" aria-label="Design credits by Siddharth Dasari (opens in a new tab)">Design credits.</a><p><a href="https://github.com/VIP-SMUR/vip-smur.github.io/actions" target="_blank" rel="noopener noreferrer" aria-label="View GitHub Actions build status (opens in a new tab)"><img alt="Last Built" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2FVIP-SMUR%2Fvip-smur.github.io%2Factions%2Fworkflows%2F119410802%2Fruns%3Fstatus%3Dcompleted%26per_page%3D1&query=%24.workflow_runs%5B0%5D.run_started_at&style=flat-square&label=Last%20Built&cacheSeconds=720"></a>
 
 theme:
   name: material


### PR DESCRIPTION
💡 **What:** Added `target="_blank"`, `rel="noopener noreferrer"`, and updated `aria-label`s for the external links ("Design credits" and "GitHub Actions build status") in the `mkdocs.yml` copyright footer.

🎯 **Why:** To improve navigation UX (users don't lose their place on the documentation site) and ensure screen reader users are properly informed when a link opens in a new tab, adhering to WCAG best practices.

♿ **Accessibility:** Screen reader users will now hear "(opens in a new tab)" for these footer links, correctly setting expectations before activation.

---
*PR created automatically by Jules for task [14584946423962485338](https://jules.google.com/task/14584946423962485338) started by @kastnerp*