### PR TITLE
🎨 Palette: Fix skipped heading levels for accessibility

### DIFF
--- a/docs/activities/dinners.md
+++ b/docs/activities/dinners.md
@@ -1,13 +1,13 @@
 # Class Dinner
 
-### Spring 2025
+## Spring 2025
 
 <figure markdown="span">
   ![VIP-SMUR Pizza Night 2025 in front of ARCH West](25-ARCHWest.jpg)
   <figcaption>VIP-SMUR Pizza Night 2025 in front of ARCH West</figcaption>
 </figure>
 
-### Fall 2024
+## Fall 2024
 
 <figure markdown="span">
   ![VIP-SMUR Dinner 2024 at Boho Taco](24-BohoTaco.jpg)

--- a/docs/activities/outreach.md
+++ b/docs/activities/outreach.md
@@ -1,6 +1,6 @@
 # Outreach & Conferences
 
-### Fall 2025
+## Fall 2025
 
 <figure markdown="span">
   ![Fall 2025 Sustainability Network Meeting](25-SustainabilityNetworkMeeting.jpeg)
@@ -9,7 +9,7 @@
   </figcaption>
 </figure>
 
-### Summer 2025
+## Summer 2025
 
 <figure markdown="span">
   ![VIP-SMUR ISyE Summer Scholars Program](25-SURS-Justin.jpg)
@@ -18,7 +18,7 @@
   </figcaption>
 </figure>
 
-### Fall 2024
+## Fall 2024
 
 <figure markdown="span">
   ![VIP-SMUR Georgia Undergraduate Research Conference 2024 in Oxford, GA](24-GURC.jpg)
@@ -34,7 +34,7 @@
   Ze Yu Jiang, Sofia Mujica, Silvia Vangelova, and Patrick Kastner</figcaption>
 </figure>
 
-### Spring 2024
+## Spring 2024
 
 <figure markdown="span">
   ![Anubha Mahajan representing VIP-SMUR at the BBISS Sustainability Showcase](24-BBISS-Mahajan.jpg)


### PR DESCRIPTION
💡 What: Fixed skipped heading levels in `docs/activities/dinners.md` and `docs/activities/outreach.md`.
🎯 Why: Going directly from an H1 (`#`) to an H3 (`###`) skips an essential document outline level. This violates WCAG 1.3.1 (Info and Relationships) and creates a confusing document outline for screen reader users trying to navigate the page structure. Changing the `###` headers to `##` resolves this issue.
📸 Before/After: Visual presentation is improved and aligned properly as H2s.
♿ Accessibility: Improved document outline structure for screen reader users, enabling them to properly navigate using heading commands.

---
*PR created automatically by Jules for task [1097852902151962034](https://jules.google.com/task/1097852902151962034) started by @kastnerp*