### PR TITLE
🎨 Palette: Fix document outline hierarchy for accessibility

### DIFF
--- a/docs/team/index.md
+++ b/docs/team/index.md
@@ -1,3 +1,5 @@
+# Team Overview
+
 ## Co-Instructors
 
 Co-instructors are domain experts who mentor specific subteams each semester, provide technical and research guidance, and help scope project direction with the class lead.


### PR DESCRIPTION
💡 What: Added an `# Team Overview` H1 header to `docs/team/index.md`.
🎯 Why: To restore semantic document outline hierarchy. The document previously skipped the top-level H1 and began with an H2 (`## Co-Instructors`), which breaks screen reader navigation by causing users to miss context when navigating by header level.
♿ Accessibility: Ensures heading structure strictly follows hierarchical flow for screen readers without skipping levels.

---
*PR created automatically by Jules for task [13185796891664843175](https://jules.google.com/task/13185796891664843175) started by @kastnerp*