### PR TITLE
🎨 Palette: Remove redundant alt text for images with figcaptions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,7 @@
 ## 2026-04-01 - [Theme Toggle Icons]
 **Learning:** The user explicitly requested that the semantics of the symbols (icons) for the color palette theme toggle should not be changed.
 **Action:** When updating the MkDocs Material palette settings in `mkdocs.yml`, always keep the default icons (`material/theme-light-dark`, `material/toggle-switch`, `material/toggle-switch-off`). Do not replace them with sun/moon or context-aware icons.
+
+## 2026-04-07 - Redundant Alt Text with Captions
+**Learning:** When images are wrapped in `<figure>` with a descriptive `<figcaption>`, providing identical or highly similar text in the image's `alt` attribute causes screen readers to read the description twice, creating a verbose and frustrating experience.
+**Action:** When an image has a `<figcaption>` that fully describes its purpose or content, leave the markdown alt text empty (e.g., `![]()`) to generate `alt=""` and avoid redundancy for screen reader users.

--- a/docs/activities/dinners.md
+++ b/docs/activities/dinners.md
@@ -3,13 +3,13 @@
 ## Spring 2025
 
 <figure markdown="span">
-  ![VIP-SMUR Pizza Night 2025 in front of ARCH West](25-ARCHWest.jpg)
+  ![](25-ARCHWest.jpg)
   <figcaption>VIP-SMUR Pizza Night 2025 in front of ARCH West</figcaption>
 </figure>
 
 ## Fall 2024
 
 <figure markdown="span">
-  ![VIP-SMUR Dinner 2024 at Boho Taco](24-BohoTaco.jpg)
+  ![](24-BohoTaco.jpg)
   <figcaption>VIP-SMUR Dinner at Boho Taco Fall 24</figcaption>
 </figure>

--- a/docs/activities/outreach.md
+++ b/docs/activities/outreach.md
@@ -3,7 +3,7 @@
 ## Fall 2025
 
 <figure markdown="span">
-  ![Fall 2025 Sustainability Network Meeting](25-SustainabilityNetworkMeeting.jpeg)
+  ![](25-SustainabilityNetworkMeeting.jpeg)
   <figcaption>
     Joseph Aerathu and Matthew Lim representing our VIP at the Fall 2025 <a href="https://research.gatech.edu/georgia-tech-sustainability-network" target="_blank" rel="noopener noreferrer" aria-label="Sustainability Network Meeting (opens in a new tab)">Sustainability Network Meeting</a>.
   </figcaption>
@@ -12,7 +12,7 @@
 ## Summer 2025
 
 <figure markdown="span">
-  ![VIP-SMUR ISyE Summer Scholars Program](25-SURS-Justin.jpg)
+  ![](25-SURS-Justin.jpg)
   <figcaption>
     Justin Xu presenting his contributions to the <a href="https://vip-smur.github.io/25sp-mponc/" target="_blank" rel="noopener noreferrer" aria-label="MPONC (opens in a new tab)">MPONC</a> project as part of the <a href="https://ugresearch.isye.gatech.edu/research-awards-programs/summer-scholars-program" target="_blank" rel="noopener noreferrer" aria-label="ISyE Summer Scholars Program (opens in a new tab)">ISyE Summer Scholars Program</a>.
   </figcaption>
@@ -21,14 +21,14 @@
 ## Fall 2024
 
 <figure markdown="span">
-  ![VIP-SMUR Georgia Undergraduate Research Conference 2024 in Oxford, GA](24-GURC.jpg)
+  ![](24-GURC.jpg)
   <figcaption><a href="https://sustainableurbansystems.com/news/announcement_25/" target="_blank" rel="noopener noreferrer" aria-label="Georgia Undergraduate Research Conference 2024 in Oxford, GA (opens in a new tab)">Georgia Undergraduate Research Conference 2024 in Oxford, GA</a>
 
   Anubha Mahajan, Jessica Hernandez, Jiayi Li, Joseph Mathew Aerathu, Sharmista Debnath, Kiana-Karla Layam,  Han-Syun Shih, Hang Xu, and Patrick Kastner. Photo credits: Han-Syun Shih</figcaption>
 </figure>
 
 <figure markdown="span">
-  ![VIP-SMUR at the GNI Symposium & Expo on Artificial Intelligence for the Built World](24-GNI.jpeg)
+  ![](24-GNI.jpeg)
   <figcaption><a href="https://sustainableurbansystems.com/news/announcement_24/" target="_blank" rel="noopener noreferrer" aria-label="GNI Symposium on AI for the Built World in Munich, Germany (opens in a new tab)">GNI Symposium on AI for the Built World in Munich, Germany.</a><br>
 
   Ze Yu Jiang, Sofia Mujica, Silvia Vangelova, and Patrick Kastner</figcaption>
@@ -37,6 +37,6 @@
 ## Spring 2024
 
 <figure markdown="span">
-  ![Anubha Mahajan representing VIP-SMUR at the BBISS Sustainability Showcase](24-BBISS-Mahajan.jpg)
+  ![](24-BBISS-Mahajan.jpg)
   <figcaption>Anubha Mahajan representing VIP-SMUR at the Spring 24 BBISS Sustainability Showcase.</figcaption>
 </figure>

--- a/docs/activities/rush.md
+++ b/docs/activities/rush.md
@@ -9,6 +9,6 @@ hide:
 We participate in the semi-annual VIP Rush which is a poster information event for prospective students.  It is typically held on the first Tuesday after registration opens. You can find details about the [upcoming VIP Rush events](https://vip.gatech.edu/rsvp-upcoming-vip-rush){ target="_blank" rel="noopener noreferrer" aria-label="upcoming VIP Rush events (opens in a new tab)" }. Please stop by to talk to our students about what we do and how you can get involved!
 
 <figure markdown="span">
-  ![VIP-Rush Spring 2025](25-VIPRush.png)
+  ![](25-VIPRush.png)
   <figcaption>VIP-Rush Spring 2025</figcaption>
 </figure>

--- a/docs/macleamy.md
+++ b/docs/macleamy.md
@@ -1,5 +1,5 @@
 <figure markdown="span">
-  ![MacLeamy Influence Curve](images/SVG/InfluenceCurveWhite.svg#dark-only){ align=left, width="640",  .off-glb}
-  ![MacLeamy Influence Curve](images/SVG/InfluenceCurveBlack.svg#light-only){ align=left, width="640", .off-glb }
+  ![](images/SVG/InfluenceCurveWhite.svg#dark-only){ align=left, width="640",  .off-glb}
+  ![](images/SVG/InfluenceCurveBlack.svg#light-only){ align=left, width="640", .off-glb }
   <figcaption><a href="https://www.youtube.com/watch?v=9bUlBYc_Gl4" target="_blank" rel="noopener noreferrer" aria-label="MacLeamy Curve (opens in a new tab)">MacLeamy Curve</a> illustrating the need for rapid performance feedback in architectural decision-making. <a href="https://www.danieldavis.com/macleamy/" target="_blank" rel="noopener noreferrer" aria-label="More information about the MacLeamy curve (opens in a new tab)">(more info)</a></figcaption>
 </figure>

--- a/docs/team/25-Fa.md
+++ b/docs/team/25-Fa.md
@@ -15,7 +15,7 @@ hide:
 
 <figure markdown="span">
 
-![Fall 2025 Group Picture at Tech Green](25-Fa_Classphoto.jpg)
+![](25-Fa_Classphoto.jpg)
 
   <figcaption>SMUR Fall 2025 Team Picture (some folks are missing)</figcaption>
 

--- a/docs/team/25-Sp.md
+++ b/docs/team/25-Sp.md
@@ -15,7 +15,7 @@ hide:
 
 <figure markdown="span">
 
-![Spring 2025 Group Picture at Tech Green](25-Sp_ClassPhoto.jpg)
+![](25-Sp_ClassPhoto.jpg)
 
   <figcaption>SMUR Spring 2025 Team Picture</figcaption>
 

--- a/docs/team/26-Sp.md
+++ b/docs/team/26-Sp.md
@@ -7,7 +7,7 @@ hide:
 
 <figure markdown="span">
 
-![Spring 2026 Team](26-Sp-ClassPhoto.jpg)
+![](26-Sp-ClassPhoto.jpg)
 
   <figcaption>SMUR Spring 2026 Team Picture</figcaption>
 


### PR DESCRIPTION
💡 What: Removed duplicate `alt` text on images inside `<figure>` blocks with descriptive `<figcaption>` elements by changing them to `![]()`. Added a journal entry to `.Jules/palette.md` for this learning.
🎯 Why: Having identical `alt` text and `<figcaption>` causes screen readers to read the same description twice, creating a frustrating and verbose UX for visually impaired users. Generating `alt=""` resolves this.
📸 Before/After: Visual presentation is identical; changes apply only to generated HTML properties.
♿ Accessibility: Eliminates duplicate announcements by screen readers, improving the navigational flow and clarity of image descriptions.

---
*PR created automatically by Jules for task [15611433142461562110](https://jules.google.com/task/15611433142461562110) started by @kastnerp*