### PR TITLE
🎨 Palette: Fix WCAG 2.5.3 violations for external links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ hide:
 ![SustainLab Logo](images/sustainlab-smur-logo-wordmark-color-white.svg#dark-only){ align=left, width="500", .off-glb}
 ![SustainLab Logo](images/sustainlab-smur-logo-wordmark-color-black.svg#light-only){ align=left, width="500", .off-glb}
 
-Welcome to the project page of the [VIP][VIP]{ target="_blank" rel="noopener noreferrer" aria-label="Vertically Integrated Projects Program (opens in a new tab)" } team Surrogate Modeling for Urban Regeneration (SMUR) at Georgia Tech.
+Welcome to the project page of the [VIP][VIP]{ target="_blank" rel="noopener noreferrer" aria-label="VIP: Vertically Integrated Projects Program (opens in a new tab)" } team Surrogate Modeling for Urban Regeneration (SMUR) at Georgia Tech.
 This course is led by Dr. Patrick Kastner, head of the [Sustainable Urban Systems Lab](https://sustain.arch.gatech.edu){ target="_blank" rel="noopener noreferrer" aria-label="Sustainable Urban Systems Lab (opens in a new tab)" }.
 
 ## 📝 The Problem

--- a/docs/macleamy.md
+++ b/docs/macleamy.md
@@ -1,5 +1,5 @@
 <figure markdown="span">
   ![](images/SVG/InfluenceCurveWhite.svg#dark-only){ align=left, width="640",  .off-glb}
   ![](images/SVG/InfluenceCurveBlack.svg#light-only){ align=left, width="640", .off-glb }
-  <figcaption><a href="https://www.youtube.com/watch?v=9bUlBYc_Gl4" target="_blank" rel="noopener noreferrer" aria-label="MacLeamy Curve (opens in a new tab)">MacLeamy Curve</a> illustrating the need for rapid performance feedback in architectural decision-making. <a href="https://www.danieldavis.com/macleamy/" target="_blank" rel="noopener noreferrer" aria-label="More information about the MacLeamy curve (opens in a new tab)">(more info)</a></figcaption>
+  <figcaption><a href="https://www.youtube.com/watch?v=9bUlBYc_Gl4" target="_blank" rel="noopener noreferrer" aria-label="MacLeamy Curve (opens in a new tab)">MacLeamy Curve</a> illustrating the need for rapid performance feedback in architectural decision-making. <a href="https://www.danieldavis.com/macleamy/" target="_blank" rel="noopener noreferrer" aria-label="(more info) about the MacLeamy curve (opens in a new tab)">(more info)</a></figcaption>
 </figure>


### PR DESCRIPTION
💡 What: Modified `aria-label` attributes on links in `docs/index.md` and `docs/macleamy.md` to ensure they include the exact visible text of the link.
🎯 Why: This fixes a WCAG 2.5.3 (Label in Name) violation. When an `aria-label` does not contain the visible text, speech-to-text users (who speak the visible text to activate the link) cannot interact with it successfully. 
♿ Accessibility: Improved compliance with WCAG 2.5.3 for users relying on voice commands or screen readers.

---
*PR created automatically by Jules for task [16814175401910742070](https://jules.google.com/task/16814175401910742070) started by @kastnerp*