### PR TITLE
🎨 Palette: Fix WCAG 2.5.3 (Label in Name) accessibility issues

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -31,3 +31,7 @@
 ## 2026-04-07 - Redundant Alt Text with Captions
 **Learning:** When images are wrapped in `<figure>` with a descriptive `<figcaption>`, providing identical or highly similar text in the image's `alt` attribute causes screen readers to read the description twice, creating a verbose and frustrating experience.
 **Action:** When an image has a `<figcaption>` that fully describes its purpose or content, leave the markdown alt text empty (e.g., `![]()`) to generate `alt=""` and avoid redundancy for screen reader users.
+
+## 2024-04-10 - ARIA Labels and Image Alt Text
+**Learning:** When a link contains only an image, the image's `alt` text serves as the visible text for speech-input users. If an `aria-label` is applied to the link, it completely overrides this name, potentially breaking speech navigation if it doesn't include the exact `alt` text.
+**Action:** When adding or updating an `aria-label` on a link whose sole content is an image with `alt` text, ensure the `aria-label` incorporates the exact `alt` text to comply with WCAG 2.5.3 (Label in Name).

--- a/docs/activities/outreach.md
+++ b/docs/activities/outreach.md
@@ -29,7 +29,7 @@
 
 <figure markdown="span">
   ![](24-GNI.jpeg)
-  <figcaption><a href="https://sustainableurbansystems.com/news/announcement_24/" target="_blank" rel="noopener noreferrer" aria-label="GNI Symposium on AI for the Built World in Munich, Germany (opens in a new tab)">GNI Symposium on AI for the Built World in Munich, Germany.</a><br>
+  <figcaption><a href="https://sustainableurbansystems.com/news/announcement_24/" target="_blank" rel="noopener noreferrer" aria-label="GNI Symposium on AI for the Built World in Munich, Germany (opens in a new tab)">GNI Symposium on AI for the Built World in Munich, Germany</a>.<br>
 
   Ze Yu Jiang, Sofia Mujica, Silvia Vangelova, and Patrick Kastner</figcaption>
 </figure>

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ This course is led by Dr. Patrick Kastner, head of the [Sustainable Urban System
 ## 📝 The Problem
 
 Many performance-related decisions in architectural and urban design happen too late in the decision-making process to ensure they suit the clients' purposes.
-We believe this hinders true [urban regeneration][urban regeneration]{ target="_blank" rel="noopener noreferrer" aria-label="Urban regeneration (opens in a new tab)" }.
+We believe this hinders true [urban regeneration][urban regeneration]{ target="_blank" rel="noopener noreferrer" aria-label="urban regeneration (opens in a new tab)" }.
 This research course challenges this status quo by developing software tools that empower communities and urban decision-makers.
 
 {% include 'macleamy.md' %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ site_description: >-
 
 # Copyright
 copyright: >-
-  Copyright &copy; 2023-2026 Sustainable Urban Systems Lab. <a href="https://siddharthdasari.com/" target="_blank" rel="noopener noreferrer" aria-label="Design credits by Siddharth Dasari (opens in a new tab)">Design credits.</a><p><a href="https://github.com/VIP-SMUR/vip-smur.github.io/actions" target="_blank" rel="noopener noreferrer" aria-label="View GitHub Actions build status (opens in a new tab)"><img alt="Last Built" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2FVIP-SMUR%2Fvip-smur.github.io%2Factions%2Fworkflows%2F119410802%2Fruns%3Fstatus%3Dcompleted%26per_page%3D1&query=%24.workflow_runs%5B0%5D.run_started_at&style=flat-square&label=Last%20Built&cacheSeconds=720"></a>
+  Copyright &copy; 2023-2026 Sustainable Urban Systems Lab. <a href="https://siddharthdasari.com/" target="_blank" rel="noopener noreferrer" aria-label="Design credits by Siddharth Dasari (opens in a new tab)">Design credits</a>.<p><a href="https://github.com/VIP-SMUR/vip-smur.github.io/actions" target="_blank" rel="noopener noreferrer" aria-label="Last Built - View GitHub Actions build status (opens in a new tab)"><img alt="Last Built" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2FVIP-SMUR%2Fvip-smur.github.io%2Factions%2Fworkflows%2F119410802%2Fruns%3Fstatus%3Dcompleted%26per_page%3D1&query=%24.workflow_runs%5B0%5D.run_started_at&style=flat-square&label=Last%20Built&cacheSeconds=720"></a>
 
 theme:
   name: material


### PR DESCRIPTION
🎨 Palette: Fix WCAG 2.5.3 (Label in Name) accessibility issues

💡 What: Updated `aria-label`s and link text to ensure the accessible name perfectly matches or starts with the visible text. This includes updating the GitHub Actions badge in `mkdocs.yml` to include its image's alt text in the aria-label, fixing casing in `docs/index.md`, and adjusting trailing punctuation in `docs/activities/outreach.md` and `mkdocs.yml`. A new entry was also added to `.Jules/palette.md` documenting this insight.
🎯 Why: To comply with WCAG 2.5.3 (Label in Name). Speech-input users navigate interfaces by speaking the visible text of controls. If an `aria-label` completely overrides the visible text (e.g. an image's `alt` text), the control becomes unclickable via voice commands.
♿ Accessibility: Ensures reliable voice control navigation and consistent screen-reader experience.

---
*PR created automatically by Jules for task [4486944370941847700](https://jules.google.com/task/4486944370941847700) started by @kastnerp*