### PR TITLE
🎨 Palette: Fix aria-label casing for Surrogate Models link to improve a11y

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ Our work will address:
 ## 🎯 Goals
 
 Conventional environmental simulation approaches in urban design are time-consuming and often incompatible with fast-paced decision-making processes.
-This VIP aims to address this by developing [surrogate models][surrogate models]{ target="_blank" rel="noopener noreferrer" aria-label="Surrogate models (opens in a new tab)" } that accelerate simulations (typically via machine learning) that offer real-time feedback to urban decision-makers, such as architects, urban designers, and policymakers. After the decision-making has been informed, we employ high-fidelity, physics-based simulations to validate our results and to produce final numbers.
+This VIP aims to address this by developing [surrogate models][surrogate models]{ target="_blank" rel="noopener noreferrer" aria-label="surrogate models (opens in a new tab)" } that accelerate simulations (typically via machine learning) that offer real-time feedback to urban decision-makers, such as architects, urban designers, and policymakers. After the decision-making has been informed, we employ high-fidelity, physics-based simulations to validate our results and to produce final numbers.
 
 Our goal is to seamlessly integrate sustainability considerations into every step of urban decision-making processes by integrating our models with industry-leading CAD tools such as `Rhino` and `Revit`, `GIS`, and making them usable even in the browser.
 


### PR DESCRIPTION
💡 **What:** Modified the `aria-label` casing for the "surrogate models" link in `docs/index.md`.
🎯 **Why:** To comply strictly with WCAG 2.5.3 (Label in Name), any `aria-label` added to a link must contain the *exact* visible text. Previously, the visible text was lowercase ("surrogate models"), but the `aria-label` was capitalized ("Surrogate models"). This mismatch can cause issues for speech-input users when navigating the site.
♿ **Accessibility:** This UX improvement directly ensures better compatibility for voice control and screen readers reading inline links mid-sentence.

---
*PR created automatically by Jules for task [17978664039163542078](https://jules.google.com/task/17978664039163542078) started by @kastnerp*